### PR TITLE
Visual artifact fixes

### DIFF
--- a/INPopoverWindow.m
+++ b/INPopoverWindow.m
@@ -42,6 +42,11 @@
     return YES;
 }
 
+- (BOOL)canBecomeMainWindow
+{
+    return NO;
+}
+
 // Override the content view accessor to return the actual popover content view
 - (NSView*)contentView
 {


### PR DESCRIPTION
I was searching for a popup/attached window class and found this one.  Thanks for making it available!

I noticed occasional visual artifacts when the popover was fading out- it seemed like the window would either flicker back to alpha 1.0 for a split second before closing, or disappear just before the fade finished.  To solve the problem, I registered the popover controller as the animation's delegate and don't trigger the close method until the fade out animation is actually finished.  This seems to fix the problem for me.
