### PR TITLE
Fixing Arc crash

### DIFF
--- a/INPopoverController.m
+++ b/INPopoverController.m
@@ -381,9 +381,11 @@
 	[self _setArrowDirection:INPopoverArrowDirectionUndefined];
 	[self _setPositionView:nil];
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
-	[[_popoverWindow animationForKey:@"alphaValue"] setDelegate:nil];	// reset delegate so it doesn't retain us
 	_screenRect = NSZeroRect;
 	_viewRect = NSZeroRect;
+    
+    // When using ARC and no animation, there is a "message sent to deallocated instance" crash if setDelegate: is not performed at the end of the event.
+    [[_popoverWindow animationForKey:@"alphaValue"] performSelector:@selector(setDelegate:) withObject:nil afterDelay:0];
 }
 
 - (void)_callDelegateMethod:(SEL)selector


### PR DESCRIPTION
The crash only occurs then using ARC and no animation, and if you do not keep any reference to the INPopoverController.
