### PR TITLE
Fixed border drawing glitch

### DIFF
--- a/INPopoverWindowFrame.m
+++ b/INPopoverWindowFrame.m
@@ -39,7 +39,11 @@
 
 - (void)drawRect:(NSRect)dirtyRect
 {
-	NSBezierPath *path = [self _popoverBezierPathWithRect:[self bounds]];
+    NSRect bounds = [self bounds];
+    if ( ( (int)self.borderWidth % 2 ) == 1) // Remove draw glitch on odd border width
+        bounds = NSInsetRect(bounds, 0.5f, 0.5f);
+    
+	NSBezierPath *path = [self _popoverBezierPathWithRect:bounds];
 	[self.color set];
 	[path fill];
 	


### PR DESCRIPTION
Border was drawn on half pixels on odd border width.

Before:
![before](https://f.cloud.github.com/assets/1267950/227912/cf8f90cc-866f-11e2-9ae7-129e8e1c0620.png)

After:
![after](https://f.cloud.github.com/assets/1267950/227913/d48ef040-866f-11e2-9c68-eb896c846f07.png)
