### PR TITLE
Compilation error with ARC

### DIFF
--- a/INPopoverController.m
+++ b/INPopoverController.m
@@ -111,7 +111,7 @@
 - (IBAction)closePopover:(id)sender
 {
 	if (![_popoverWindow isVisible]) { return; }
-	if ([sender isKindOfClass:[NSNotification class]] && [[sender name] isEqualToString:NSWindowDidResignKeyNotification]) {
+	if ([sender isKindOfClass:[NSNotification class]] && [[(NSNotification*)sender name] isEqualToString:NSWindowDidResignKeyNotification]) {
 		// ignore "resign key" notification sent when app becomes inactive unless closesWhenApplicationBecomesInactive is enabled
 		if (!self.closesWhenApplicationBecomesInactive && ![NSApp isActive])
 			return;


### PR DESCRIPTION
ARC + Xcode 4.6.2
Adding cast (NSNotification)
INPopoverController.m 114:
Multiple methods named 'name' found with mismatched result, parameter type or attributes
